### PR TITLE
Python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.5"
 env:
   - SUNDIALS=ubuntu-precise
   - SUNDIALS=anaconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - "2.7"
-  - "3.5"
+  - "3.7"
 env:
   - SUNDIALS=ubuntu-precise
   - SUNDIALS=anaconda

--- a/src/docs/conf.py
+++ b/src/docs/conf.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 # -*- coding: utf-8 -*-
 #
 # MEANS documentation build configuration file, created by
@@ -31,10 +32,6 @@ print(sys.path)
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-
-import sys
-import os
-import shlex
 
 # Make sure sphinx finds the packages
 code_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -336,33 +333,33 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return Mock()
 
-MOCK_MODULES = [ 'cython', 
+MOCK_MODULES = [ 'cython',
 
-                'matplotlib',  
+                'matplotlib',
                 'matplotlib.artist',
-                
+
                 'sbml',
-                
+
                 'numpy',
                 'numpy.testing',
-                
+
                 'assimulo',
                 'assimulo.problem',
                 'assimulo.solvers',
                 'assimulo.solvers.sundials',
                 'assimulo.solvers.runge_kutta',
                 'assimulo.exception',
-                
+
                 'sympy',
-                'sympy.utilities.autowrap', 
+                'sympy.utilities.autowrap',
                 'sympy.utilities',
-                'sympy.core.sympify', 
+                'sympy.core.sympify',
                 'sympy.core',
                 'sympy.utilities.iterables',
-                
+
                 'scipy',
                 'scipy.optimize',
-                'scipy.special']  
+                'scipy.special']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # Document __init__ methods

--- a/src/docs/serve_docs.py
+++ b/src/docs/serve_docs.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import tornado.ioloop
 import tornado.web
 

--- a/src/means/__init__.py
+++ b/src/means/__init__.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, print_function
 
-import io
-
+from means import compat
 from means import core
 from means import approximation
 from means import inference
+from means import io
 from means import simulation
 from means import util
 

--- a/src/means/__init__.py
+++ b/src/means/__init__.py
@@ -1,11 +1,14 @@
-import io
-import core
-import approximation
-import inference
-import simulation
-import util
+from __future__ import absolute_import, print_function
 
-from core import *
-from simulation import *
-from inference import *
-from approximation import *
+import io
+
+from means import core
+from means import approximation
+from means import inference
+from means import simulation
+from means import util
+
+from .core import *
+from .simulation import *
+from .inference import *
+from .approximation import *

--- a/src/means/approximation/__init__.py
+++ b/src/means/approximation/__init__.py
@@ -1,5 +1,7 @@
-import lna
-import mea
+from __future__ import absolute_import, print_function
 
-from lna import *
-from mea import *
+from . import lna
+from . import mea
+
+from .lna import *
+from .mea import *

--- a/src/means/approximation/approximation_baseclass.py
+++ b/src/means/approximation/approximation_baseclass.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 class ApproximationBaseClass(object):
     """
     A class of explicit generators for ordinary differential equations required to simulate the model provided.

--- a/src/means/approximation/lna/__init__.py
+++ b/src/means/approximation/lna/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Linear Noise Approximation
 -----
@@ -9,7 +10,7 @@ Example:
 >>> from means.approximation.lna.lna import lna_approximation
 >>> from means.examples.sample_models import MODEL_P53
 >>> ode_problem = lna_approximation(MODEL_P53)
->>> print ode_problem
+>>> print(ode_problem)
 
 The result is an :class:`means.core.problems.ODEProblem`. Typically, it would be further used to
 perform simulations (see :mod:`~means.simulation`) and inference (see :mod:`~means.inference`).
@@ -20,4 +21,4 @@ BMC Bioinformatics, vol. 10, no. 1, p. 343, Oct. 2009.
 
 ------------
 """
-from lna import LinearNoiseApproximation, lna_approximation
+from .lna import LinearNoiseApproximation, lna_approximation

--- a/src/means/approximation/lna/lna.py
+++ b/src/means/approximation/lna/lna.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import operator
 
 import sympy as sp

--- a/src/means/approximation/lna/lna.py
+++ b/src/means/approximation/lna/lna.py
@@ -6,6 +6,7 @@ import sympy as sp
 
 from means.approximation.approximation_baseclass import ApproximationBaseClass
 from means.core import Moment, VarianceTerm, ODEProblem
+from means.compat import reduce
 
 
 def lna_approximation(model):

--- a/src/means/approximation/mea/__init__.py
+++ b/src/means/approximation/mea/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Moment Expansion Approximation
 -----
@@ -14,7 +15,7 @@ The function :func:`mea_approximation` should provide all the necessary options.
 >>> ode_problem = mea_approximation(MODEL_P53,max_order=2)
 >>> # equivalent to
 >>> # ode_problem = mea_approximation(MODEL_P53, max_order=2, closure="scalar", value=0)
->>> print ode_problem
+>>> print(ode_problem)
 
 The result is an :class:`means.core.problems.ODEProblem`. Typically, it would be further used to
 perform simulations (see :mod:`~means.simulation`) and inference (see :mod:`~means.inference`).
@@ -25,4 +26,4 @@ perform simulations (see :mod:`~means.simulation`) and inference (see :mod:`~mea
 
 ------------
 """
-from moment_expansion_approximation import MomentExpansionApproximation, mea_approximation
+from .moment_expansion_approximation import MomentExpansionApproximation, mea_approximation

--- a/src/means/approximation/mea/closure_gamma.py
+++ b/src/means/approximation/mea/closure_gamma.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Gamma moment closure
 ------
@@ -6,7 +7,8 @@ This part of the package provides the original the Gamma closure.
 """
 
 import sympy as sp
-from closure_scalar import ClosureBase
+
+from .closure_scalar import ClosureBase
 from means.util.sympyhelpers import substitute_all, product
 
 class GammaClosure(ClosureBase):

--- a/src/means/approximation/mea/closure_gamma.py
+++ b/src/means/approximation/mea/closure_gamma.py
@@ -114,7 +114,7 @@ class GammaClosure(ClosureBase):
             alpha_m = [self._gamma_factorial(a,n) for n in range(2, n_moment+1)]
 
             # Substitute alpha term for symbolic species
-            subs_pairs += zip(Y_to_substitute, alpha_m)
+            subs_pairs += list(zip(Y_to_substitute, alpha_m))
             subs_pairs.append((symbolic_species[i], a)) # Add first order expression to the end
         Y_exprs = substitute_all(Y_exprs, subs_pairs)
 

--- a/src/means/approximation/mea/closure_log_normal.py
+++ b/src/means/approximation/mea/closure_log_normal.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Log-normal moment closure
 ------
@@ -5,8 +6,8 @@ Log-normal moment closure
 This part of the package provides the original the Log-normal closure.
 """
 
-
 import sympy as sp
+
 from closure_scalar import ClosureBase
 
 class LogNormalClosure(ClosureBase):
@@ -115,6 +116,3 @@ class LogNormalClosure(ClosureBase):
         # univariate case: log covariances are 0s.
         else:
             return sp.Integer(0)
-
-
-

--- a/src/means/approximation/mea/closure_log_normal.py
+++ b/src/means/approximation/mea/closure_log_normal.py
@@ -8,7 +8,7 @@ This part of the package provides the original the Log-normal closure.
 
 import sympy as sp
 
-from closure_scalar import ClosureBase
+from .closure_scalar import ClosureBase
 
 class LogNormalClosure(ClosureBase):
     """

--- a/src/means/approximation/mea/closure_normal.py
+++ b/src/means/approximation/mea/closure_normal.py
@@ -11,6 +11,7 @@ import sympy as sp
 from sympy.utilities.iterables import multiset_partitions
 
 from means.util.sympyhelpers import product
+from means.compat import reduce
 from .closure_scalar import ClosureBase
 
 

--- a/src/means/approximation/mea/closure_normal.py
+++ b/src/means/approximation/mea/closure_normal.py
@@ -1,15 +1,17 @@
+from __future__ import absolute_import, print_function
 """
 Normal moment closure
 ------
 
 This part of the package provides the original the Normal (Gaussian) closure.
 """
+import operator
 
 import sympy as sp
 from sympy.utilities.iterables import multiset_partitions
-import operator
+
 from means.util.sympyhelpers import product
-from closure_scalar import ClosureBase
+from .closure_scalar import ClosureBase
 
 
 class NormalClosure(ClosureBase):
@@ -123,4 +125,3 @@ class NormalClosure(ClosureBase):
             if all([(len(k) == 2) for k in p]):
                 # retrieve index in original list
                 yield [[list_for_par[i] for i in k] for k in p]
-

--- a/src/means/approximation/mea/closure_scalar.py
+++ b/src/means/approximation/mea/closure_scalar.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Scalar moment closure
 ------
@@ -7,9 +8,8 @@ This part of the package provides the original
 as well as the base class for all closers.
 
 """
-
-
 import sympy as sp
+
 from means.util.sympyhelpers import substitute_all
 
 

--- a/src/means/approximation/mea/dmu_over_dt.py
+++ b/src/means/approximation/mea/dmu_over_dt.py
@@ -1,5 +1,9 @@
+from __future__ import absolute_import, print_function
+
 import itertools
+
 import sympy as sp
+
 from means.approximation.mea.mea_helpers import get_one_over_n_factorial, derive_expr_from_counter_entry
 
 

--- a/src/means/approximation/mea/eq_central_moments.py
+++ b/src/means/approximation/mea/eq_central_moments.py
@@ -1,4 +1,7 @@
+from __future__ import absolute_import, print_function
+
 import sympy as sp
+
 from means.approximation.mea.eq_mixed_moments import DBetaOverDtCalculator
 from means.approximation.mea.mea_helpers import make_k_chose_e
 from means.util.sympyhelpers import sum_of_cols, product, sympy_sum_list

--- a/src/means/approximation/mea/eq_mixed_moments.py
+++ b/src/means/approximation/mea/eq_mixed_moments.py
@@ -1,5 +1,9 @@
+from __future__ import absolute_import, print_function
+
 import itertools
+
 import sympy as sp
+
 from means.approximation.mea.mea_helpers import get_one_over_n_factorial, derive_expr_from_counter_entry, make_k_chose_e
 from means.util.sympyhelpers import sum_of_cols, product
 from means.util.decorators import cache
@@ -103,8 +107,6 @@ class DBetaOverDtCalculator(object):
 
         derives = sp.Matrix([derive_expr_from_counter_entry(expr, self.__species, tuple(c.n_vector))
                              for c in self.__n_counter])
-
-
 
         # Computes the factorial terms for EACH entry in COUNTER
         factorial_terms = sp.Matrix([get_one_over_n_factorial(tuple(c.n_vector)) for c in self.__n_counter])

--- a/src/means/approximation/mea/mea_helpers.py
+++ b/src/means/approximation/mea/mea_helpers.py
@@ -11,6 +11,7 @@ import operator
 
 import sympy as sp
 
+from means.compat import reduce
 from means.util.decorators import cache
 from means.util.sympyhelpers import product
 

--- a/src/means/approximation/mea/mea_helpers.py
+++ b/src/means/approximation/mea/mea_helpers.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 MEA helper functions.
 -------
@@ -7,7 +8,9 @@ functions for the rest :mod:`~means.approximation.mea`.
 """
 
 import operator
+
 import sympy as sp
+
 from means.util.decorators import cache
 from means.util.sympyhelpers import product
 

--- a/src/means/approximation/mea/moment_expansion_approximation.py
+++ b/src/means/approximation/mea/moment_expansion_approximation.py
@@ -5,11 +5,11 @@ import sympy as sp
 from means.core import ODEProblem
 from means.approximation.approximation_baseclass import ApproximationBaseClass
 from means.util.moment_counters import generate_n_and_k_counters
+from means.util.sympyhelpers import substitute_all, quick_solve
 
 from .dmu_over_dt import generate_dmu_over_dt
 from .eq_central_moments import eq_central_moments
 from .raw_to_central import raw_to_central
-from .means.util.sympyhelpers import substitute_all, quick_solve
 
 from .closure_gamma import GammaClosure
 from .closure_log_normal import LogNormalClosure

--- a/src/means/approximation/mea/moment_expansion_approximation.py
+++ b/src/means/approximation/mea/moment_expansion_approximation.py
@@ -1,5 +1,4 @@
-
-
+from __future__ import absolute_import, print_function
 
 import sympy as sp
 
@@ -7,16 +6,15 @@ from means.core import ODEProblem
 from means.approximation.approximation_baseclass import ApproximationBaseClass
 from means.util.moment_counters import generate_n_and_k_counters
 
-from dmu_over_dt import generate_dmu_over_dt
-from eq_central_moments import eq_central_moments
-from raw_to_central import raw_to_central
-from means.util.sympyhelpers import substitute_all, quick_solve
+from .dmu_over_dt import generate_dmu_over_dt
+from .eq_central_moments import eq_central_moments
+from .raw_to_central import raw_to_central
+from .means.util.sympyhelpers import substitute_all, quick_solve
 
-
-from closure_gamma import GammaClosure
-from closure_log_normal import LogNormalClosure
-from closure_normal import NormalClosure
-from closure_scalar import ScalarClosure
+from .closure_gamma import GammaClosure
+from .closure_log_normal import LogNormalClosure
+from .closure_normal import NormalClosure
+from .closure_scalar import ScalarClosure
 
 
 def mea_approximation(model, max_order, closure='scalar', *closure_args, **closure_kwargs):
@@ -218,4 +216,3 @@ class MomentExpansionApproximation(ApproximationBaseClass):
         out_exprs = substitute_all(central_moments_exprs, substitution_pairs)
 
         return out_exprs
-

--- a/src/means/approximation/mea/raw_to_central.py
+++ b/src/means/approximation/mea/raw_to_central.py
@@ -1,5 +1,9 @@
+from __future__ import absolute_import, print_function
+
 import operator
+
 import sympy as sp
+
 from means.approximation.mea.mea_helpers import make_k_chose_e
 
 

--- a/src/means/approximation/mea/raw_to_central.py
+++ b/src/means/approximation/mea/raw_to_central.py
@@ -5,6 +5,7 @@ import operator
 import sympy as sp
 
 from means.approximation.mea.mea_helpers import make_k_chose_e
+from means.compat import reduce
 
 
 def _make_alpha(n_vec, k_vec, ymat):

--- a/src/means/compat.py
+++ b/src/means/compat.py
@@ -1,0 +1,53 @@
+import sys
+import itertools
+
+PY2 = sys.version_info[0] < 3
+
+try:
+    # py2
+    from StringIO import StringIO
+except ImportError:
+    # py3
+    from io import StringIO
+
+try:
+    # py2
+    reduce
+except NameError:
+    # py3
+    from functools import reduce
+
+try:
+    # py2
+    string_types = basestring
+    text_type = unicode
+except NameError:
+    # py3
+    string_types = (str,)
+    text_type = str
+
+try:
+    # py2
+    zip = itertools.izip
+except AttributeError:
+    # py3
+    pass # builtins.zip already equivalent to py2 itertools.izip
+
+def unicode_compatible(cls):
+    if PY2:
+        cls.__unicode__ = cls.__str__
+        cls.__str__ = lambda self: self.__unicode__().encode('utf8')
+    return cls
+
+try:
+    dict.iteritems
+except AttributeError:
+    # py3
+    def iteritems(d):
+        for item in d.items():
+            yield item
+else:
+    # py2
+    def iteritems(d):
+        for item in d.iteritems():
+            yield item

--- a/src/means/compat.py
+++ b/src/means/compat.py
@@ -12,7 +12,7 @@ except ImportError:
 
 try:
     # py2
-    reduce
+    reduce = reduce
 except NameError:
     # py3
     from functools import reduce

--- a/src/means/core/__init__.py
+++ b/src/means/core/__init__.py
@@ -13,6 +13,6 @@ are exposed by this module.
 Finally, the :class:`Model` class, which provides a standard interface to describe a biological model,
 and can be thought to be the center of the whole package, is also implemented here.
 """
-from descriptors import Descriptor, VarianceTerm, Moment, ODETermBase
-from problems import StochasticProblem, ODEProblem
-from model import Model
+from .descriptors import Descriptor, VarianceTerm, Moment, ODETermBase
+from .problems import StochasticProblem, ODEProblem
+from .model import Model

--- a/src/means/core/descriptors.py
+++ b/src/means/core/descriptors.py
@@ -15,7 +15,7 @@ defined below.
 import numpy as np
 import sympy
 
-from means.compat import text_type, unicode_compatible
+from means.compat import unicode_compatible
 from means.io.serialise import SerialisableObject
 
 

--- a/src/means/core/descriptors.py
+++ b/src/means/core/descriptors.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Descriptors
 -----------
@@ -13,6 +14,7 @@ defined below.
 """
 import numpy as np
 import sympy
+
 from means.io.serialise import SerialisableObject
 
 

--- a/src/means/core/descriptors.py
+++ b/src/means/core/descriptors.py
@@ -15,6 +15,7 @@ defined below.
 import numpy as np
 import sympy
 
+from means.compat import text_type, unicode_compatible
 from means.io.serialise import SerialisableObject
 
 
@@ -37,6 +38,7 @@ class Descriptor(SerialisableObject):
         """
         return str(self)
 
+@unicode_compatible
 class ODETermBase(Descriptor):
     """
     Base class for explaining terms in the ODE expressions.
@@ -72,9 +74,6 @@ class ODETermBase(Descriptor):
         return str(self)
 
     def __str__(self):
-        return unicode(self).encode('utf8')
-
-    def __unicode__(self):
         return u'{0}({1})'.format(self.__class__.__name__, self.symbol)
 
     def mathtext(self):
@@ -84,7 +83,7 @@ class ODETermBase(Descriptor):
     def _repr_latex(self):
         return '${0}$'.format(self.symbol)
 
-
+@unicode_compatible
 class VarianceTerm(ODETermBase):
     """
     Signifies that a particular equation generated from the model is part of a Variance Term
@@ -110,7 +109,7 @@ class VarianceTerm(ODETermBase):
     def position(self):
         return self._position
 
-    def __unicode__(self):
+    def __str__(self):
         return u'{0}(position{1}, symbol={2})'.format(self.__class__.__name__, self.position, self.symbol)
 
     def _repr_latex_(self):
@@ -127,7 +126,7 @@ class VarianceTerm(ODETermBase):
         mapping = [('symbol', str(data.symbol)), ('position', data.position)]
         return dumper.represent_mapping(cls.yaml_tag, mapping)
 
-
+@unicode_compatible
 class Moment(ODETermBase):
     """
     An annotator for ODE expressions that describes that a particular expression in a set of ODEs corresponds to a Moment
@@ -220,11 +219,8 @@ class Moment(ODETermBase):
         """
         return (self.n_vector >= other.n_vector).all()
 
-    def __unicode__(self):
-        return u'{self.__class__.__name__}({self.n_vector!r}, symbol={self.symbol!r})'.format(self=self)
-
     def __str__(self):
-        return unicode(self).encode("utf8")
+        return u'{self.__class__.__name__}({self.n_vector!r}, symbol={self.symbol!r})'.format(self=self)
 
     def __repr__(self):
         return str(self)

--- a/src/means/core/model.py
+++ b/src/means/core/model.py
@@ -44,11 +44,12 @@ and stochastic simulations (e.g. :mod:`~means.simulation.ssa`).
 
 import sympy
 
+from means.compat import text_type, unicode_compatible
 from means.io.latex import LatexPrintableObject
 from means.io.serialise import SerialisableObject
 from means.util.sympyhelpers import to_sympy_matrix, to_sympy_column_matrix, to_list_of_symbols, sympy_expressions_equal
 
-
+@unicode_compatible
 class Model(SerialisableObject, LatexPrintableObject):
     """
     Stores the model of reactions we want to analyse
@@ -152,7 +153,7 @@ class Model(SerialisableObject, LatexPrintableObject):
         return len(self.__parameters)
 
 
-    def __unicode__(self):
+    def __str__(self):
         return u"{0.__class__!r}\n" \
                u"Species: {0.species!r}\n" \
                u"Parameters: {0.parameters!r}\n" \
@@ -162,9 +163,6 @@ class Model(SerialisableObject, LatexPrintableObject):
                u"\n" \
                u"Propensities:\n" \
                u"{0.propensities!r}".format(self)
-
-    def __str__(self):
-        return unicode(self).encode("utf8")
 
     def __repr__(self):
         return str(self)

--- a/src/means/core/model.py
+++ b/src/means/core/model.py
@@ -44,7 +44,7 @@ and stochastic simulations (e.g. :mod:`~means.simulation.ssa`).
 
 import sympy
 
-from means.compat import text_type, unicode_compatible
+from means.compat import unicode_compatible
 from means.io.latex import LatexPrintableObject
 from means.io.serialise import SerialisableObject
 from means.util.sympyhelpers import to_sympy_matrix, to_sympy_column_matrix, to_list_of_symbols, sympy_expressions_equal

--- a/src/means/core/model.py
+++ b/src/means/core/model.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Model
 -----
@@ -31,7 +32,7 @@ An example showing the p53 model could be encoded:
 
 Printing the model to ensure everything is all right:
 
->>> print my_model
+>>> print(my_model)
 
 Typically, a model would be used for approximation (e.g.
 :mod:`~means.approximation.mea.moment_expansion_approximation`, or
@@ -42,6 +43,7 @@ and stochastic simulations (e.g. :mod:`~means.simulation.ssa`).
 """
 
 import sympy
+
 from means.io.latex import LatexPrintableObject
 from means.io.serialise import SerialisableObject
 from means.util.sympyhelpers import to_sympy_matrix, to_sympy_column_matrix, to_list_of_symbols, sympy_expressions_equal

--- a/src/means/core/problems.py
+++ b/src/means/core/problems.py
@@ -28,6 +28,7 @@ from sympy.utilities.autowrap import autowrap
 
 from means.core.model import Model
 from means.core.descriptors import Moment
+from means.compat import string_types, unicode_compatible, iteritems
 from means.io.latex import LatexPrintableObject
 from means.io.serialise import SerialisableObject
 from means.util.memoisation import memoised_property, MemoisableObject
@@ -35,6 +36,7 @@ from means.util.sympyhelpers import to_list_of_symbols, to_sympy_column_matrix, 
 from means.util.sympyhelpers import sympy_expressions_equal
 
 
+@unicode_compatible
 class ODEProblem(SerialisableObject, LatexPrintableObject, MemoisableObject):
     """
     Creates a `ODEProblem` object that stores a system of ODEs describing the kinetic of a system.
@@ -93,7 +95,7 @@ class ODEProblem(SerialisableObject, LatexPrintableObject, MemoisableObject):
 
     @property
     def number_of_species(self):
-        species = [it[1]  for it in self._descriptions_dict.iteritems() if
+        species = [it[1]  for it in iteritems(self._descriptions_dict) if
             isinstance(it[1], Moment) and it[1].order == 1]
 
         return len(species)
@@ -157,7 +159,7 @@ class ODEProblem(SerialisableObject, LatexPrintableObject, MemoisableObject):
         :type symbol: basestring|:class:`sympy.Symbol`
         :return:
         """
-        if isinstance(symbol, basestring):
+        if isinstance(symbol, string_types):
             symbol = sympy.Symbol(symbol)
 
         try:
@@ -165,9 +167,7 @@ class ODEProblem(SerialisableObject, LatexPrintableObject, MemoisableObject):
         except KeyError:
             raise KeyError("Symbol {0!r} not found in left-hand-side of the equations".format(symbol))
 
-
-
-    def __unicode__(self):
+    def __str__(self):
         equations_pretty_str = '\n\n'.join(['{0!r}:\n    {1!r}'.format(x, y) for x, y in zip(self.left_hand_side_descriptors,
                                                                                            self.right_hand_side)])
         return u"{0.__class__!r}\n" \
@@ -176,9 +176,6 @@ class ODEProblem(SerialisableObject, LatexPrintableObject, MemoisableObject):
                u"\n" \
                u"Equations:\n\n" \
                u"{1}\n".format(self, equations_pretty_str)
-
-    def __str__(self):
-        return unicode(self).encode("utf8")
 
     def __repr__(self):
         return str(self)

--- a/src/means/core/problems.py
+++ b/src/means/core/problems.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Problems
 --------

--- a/src/means/core/problems.py
+++ b/src/means/core/problems.py
@@ -212,23 +212,23 @@ class ODEProblem(SerialisableObject, LatexPrintableObject, MemoisableObject):
         STRING_MOM = 'List of moments:'
 
         left_hand_side = self.left_hand_side_descriptors
-        preamble = ["\documentclass{article}"]
-        preamble += ["\usepackage[landscape, margin=0.5in, a3paper]{geometry}"]
+        preamble = ["\\documentclass{article}"]
+        preamble += ["\\usepackage[landscape, margin=0.5in, a3paper]{geometry}"]
         lines = ["\\begin{document}"]
-        lines += ["\section*{%s}" % STRING_RIGHT_HAND]
+        lines += ["\\section*{%s}" % STRING_RIGHT_HAND]
 
-        lines += ["$\dot {0} = {1} {2}$".format(str(sympy.latex(lhs.symbol)), str(sympy.latex(rhs)), r"\\")
+        lines += ["$\\dot {0} = {1} {2}$".format(str(sympy.latex(lhs.symbol)), str(sympy.latex(rhs)), r"\\")
                     for (rhs, lhs) in zip(self.right_hand_side, left_hand_side)]
 
         lines += [r"\\"] * 5
 
-        lines += ["\section*{%s}" % STRING_MOM]
+        lines += ["\\section*{%s}" % STRING_MOM]
 
 
-        lines += ["$\dot {0}$: {1} {2}".format(str(sympy.latex(lhs.symbol)), str(lhs), r"\\")
+        lines += ["$\\dot {0}$: {1} {2}".format(str(sympy.latex(lhs.symbol)), str(lhs), r"\\")
                        for lhs in left_hand_side if isinstance(lhs, Moment)]
 
-        lines += ["\end{document}"]
+        lines += ["\\end{document}"]
 
         return '\n'.join(preamble + lines)
 

--- a/src/means/examples/__init__.py
+++ b/src/means/examples/__init__.py
@@ -1,1 +1,3 @@
-from sample_models import MODEL_DIMERISATION, MODEL_HES1, MODEL_LOTKA_VOLTERRA, MODEL_MICHAELIS_MENTEN, MODEL_P53
+from __future__ import absolute_import, print_function
+
+from .sample_models import MODEL_DIMERISATION, MODEL_HES1, MODEL_LOTKA_VOLTERRA, MODEL_MICHAELIS_MENTEN, MODEL_P53

--- a/src/means/examples/sample_models.py
+++ b/src/means/examples/sample_models.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Sample Models
 -----
@@ -6,7 +7,7 @@ This part of the package provides examples of simple
 and well characterised models to play with.
 
 >>> from means.examples.sample_models import MODEL_P53
->>> print MODEL_P53
+>>> print(MODEL_P53)
 
 """
 

--- a/src/means/inference/__init__.py
+++ b/src/means/inference/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Parameter Inference
 -----
@@ -14,5 +15,5 @@ or inference from random starting points (:class:`~means.inference.InferenceWith
 Some basic inference result plotting functionality is also provided by the package, see the documentation for
 :class:`~means.inference.InferenceResult` for more information on this.
 """
-from inference import *
-from results import InferenceResult, InferenceResultsCollection
+from .inference import *
+from .results import InferenceResult, InferenceResultsCollection

--- a/src/means/inference/distances.py
+++ b/src/means/inference/distances.py
@@ -13,6 +13,7 @@ import numpy as np
 from scipy.special import gammaln
 
 from means.core import Moment
+from means.compat import iteritems
 from means.simulation.solvers import NP_FLOATING_POINT_PRECISION
 
 def _supported_distances_lookup():
@@ -157,7 +158,7 @@ def _compile_mean_variance_lookup(trajectories):
             variances[species_id] = trajectory.values
 
     combined_lookup = {}
-    for species, mean in means.iteritems():
+    for species, mean in iteritems(means):
         combined_lookup[species] = _MeanVariance(mean, variances[species])
 
     return combined_lookup

--- a/src/means/inference/distances.py
+++ b/src/means/inference/distances.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Distances
 -----
@@ -7,10 +8,12 @@ Distance functions are typically required for parameter inference (see :mod:`mea
 """
 
 from collections import namedtuple
+
 import numpy as np
+from scipy.special import gammaln
+
 from means.core import Moment
 from means.simulation.solvers import NP_FLOATING_POINT_PRECISION
-from scipy.special import gammaln
 
 def _supported_distances_lookup():
     return {'sum_of_squares': sum_of_squares,

--- a/src/means/inference/hypercube.py
+++ b/src/means/inference/hypercube.py
@@ -1,5 +1,9 @@
+from __future__ import absolute_import, print_function
+
 import random
+
 import numpy as np
+
 def hypercube(number_of_samples, variables):
     """
     This implements Latin Hypercube Sampling.

--- a/src/means/inference/inference.py
+++ b/src/means/inference/inference.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 from scipy.optimize import fmin
 from sympy import Symbol
 

--- a/src/means/inference/inference.py
+++ b/src/means/inference/inference.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, print_function
 from scipy.optimize import fmin
 from sympy import Symbol
 
+from means.compat import iteritems
 from means.inference.distances import get_distance_function
 from means.inference.hypercube import hypercube
 from means.inference.parallelisation import raw_results_in_parallel
@@ -291,7 +292,7 @@ class Inference(SerialisableObject, MemoisableObject):
         # Variable parameters are assumed to be validated here and only in {symbol : range_} format
         variable_parameters = data.variable_parameters
         # Convert key to string as sympy is a bit too smart and does not allow sorting symbols
-        variable_parameters = {str(key): value for key, value in variable_parameters.iteritems()}
+        variable_parameters = {str(key): value for key, value in iteritems(variable_parameters)}
 
         mapping = [('problem', data.problem),
                    ('starting_parameters', data.starting_parameters),
@@ -355,9 +356,8 @@ class Inference(SerialisableObject, MemoisableObject):
 
         constraints = parameter_constraints + initial_condition_constraints
 
-        assert(constraints is None or len(constraints) == len(filter(lambda x: x[1],
-                                                                     starting_parameters_with_variability +
-                                                                     starting_conditions_with_variability)))
+        assert(constraints is None or len(constraints) == sum(
+            bool(x[1]) for x in starting_parameters_with_variability + starting_conditions_with_variability))
         self.__constraints = constraints
 
         self.__observed_trajectories = observed_trajectories
@@ -418,7 +418,7 @@ class Inference(SerialisableObject, MemoisableObject):
             variable_parameters = {p: None for p in variable_parameters}
 
         variable_parameters_symbolic = {}
-        for parameter, range_ in variable_parameters.iteritems():
+        for parameter, range_ in iteritems(variable_parameters):
             if not isinstance(parameter, Symbol):
                 parameter = Symbol(parameter)
             if range_ is not None:

--- a/src/means/inference/parallelisation.py
+++ b/src/means/inference/parallelisation.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Parameter Inference Parallelisation
 ----

--- a/src/means/inference/plotting.py
+++ b/src/means/inference/plotting.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import, print_function
 
 import numpy as np
 
+from means.compat import iteritems
+
 def _label_axes(ax, x_label, y_label, fontsize=20, rotate_x_ticks=True):
     ax.set_xlabel(x_label, fontsize=fontsize)
     ax.set_ylabel(y_label, fontsize=fontsize)
@@ -30,7 +32,8 @@ def plot_contour(x, y, z, x_label, y_label, ax=None, fmt='%.3f', *args, **kwargs
             seen_values[xi, yi] = [zi]
 
     new_x, new_y, new_z = [], [], []
-    for (xi, yi), zi_list in seen_values.iteritems():
+    for xyi, zi_list in iteritems(seen_values):
+        xi, yi = xyi
         new_x.append(xi)
         new_y.append(yi)
 

--- a/src/means/inference/plotting.py
+++ b/src/means/inference/plotting.py
@@ -1,4 +1,7 @@
+from __future__ import absolute_import, print_function
+
 import numpy as np
+
 def _label_axes(ax, x_label, y_label, fontsize=20, rotate_x_ticks=True):
     ax.set_xlabel(x_label, fontsize=fontsize)
     ax.set_ylabel(y_label, fontsize=fontsize)
@@ -108,4 +111,3 @@ def plot_2d_trajectory(x, y,
 
     if legend:
         ax.legend()
-

--- a/src/means/inference/results.py
+++ b/src/means/inference/results.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Inference Results
 -------

--- a/src/means/inference/results.py
+++ b/src/means/inference/results.py
@@ -5,14 +5,15 @@ Inference Results
 This part of the package provides classes to store and manage the results
 of inference.
 """
+from means.compat import unicode_compatible, iteritems
 from means.inference.plotting import plot_contour, plot_2d_trajectory
-
 from means.io.serialise import SerialisableObject
 from means.util.logs import get_logger
 from means.util.memoisation import memoised_property, MemoisableObject
 
 logger = get_logger(__name__)
 
+@unicode_compatible
 class ConvergenceStatusBase(SerialisableObject):
 
     def __init__(self, convergence_achieved):
@@ -26,11 +27,8 @@ class ConvergenceStatusBase(SerialisableObject):
     def _convergence_achieved_str(self):
         return 'convergence achieved' if self.convergence_achieved else 'convergence not achieved'
 
-    def __unicode__(self):
-        return u"<Inference {self._convergence_achieved_str}>".format(self=self)
-
     def __str__(self):
-        return unicode(self).encode("utf8")
+        return u"<Inference {self._convergence_achieved_str}>".format(self=self)
 
     def __repr__(self):
         return str(self)
@@ -41,6 +39,8 @@ class ConvergenceStatusBase(SerialisableObject):
 
         return self.convergence_achieved == other.convergence_achieved
 
+
+@unicode_compatible
 class NormalConvergenceStatus(ConvergenceStatusBase):
 
     yaml_tag = '!convergence-status'
@@ -65,7 +65,7 @@ class NormalConvergenceStatus(ConvergenceStatusBase):
     def warn_flag(self):
         return self.__warn_flag
 
-    def __unicode__(self):
+    def __str__(self):
         return u"<Inference {self._convergence_achieved_str} " \
                u"in {self.iterations_taken} iterations " \
                u"and {self.function_calls_made} function calls>".format(self=self)
@@ -87,6 +87,7 @@ class NormalConvergenceStatus(ConvergenceStatusBase):
             and self.warn_flag == other.warn_flag
 
 
+@unicode_compatible
 class SolverErrorConvergenceStatus(ConvergenceStatusBase):
 
     yaml_tag = '!multiple-solver-errors'
@@ -94,7 +95,7 @@ class SolverErrorConvergenceStatus(ConvergenceStatusBase):
     def __init__(self):
         super(SolverErrorConvergenceStatus, self).__init__(False)
 
-    def __unicode__(self):
+    def __str__(self):
         return u"<Inference {self._convergence_achieved_str} " \
                u"as it was cancelled after maximum number of solver errors occurred.".format(self=self)
 
@@ -109,6 +110,8 @@ class SolverErrorConvergenceStatus(ConvergenceStatusBase):
 
         return super(SolverErrorConvergenceStatus, self).__eq__(other)
 
+
+@unicode_compatible
 class InferenceResultsCollection(SerialisableObject):
     __inference_results = None
 
@@ -153,7 +156,7 @@ class InferenceResultsCollection(SerialisableObject):
     def best(self):
         return self.__inference_results[0]
 
-    def __unicode__(self):
+    def __str__(self):
         return u"""
         {self.__class__!r}
 
@@ -162,18 +165,13 @@ class InferenceResultsCollection(SerialisableObject):
         {self.best!r}
         """.format(self=self)
 
-    def __str__(self):
-        return unicode(self).encode("utf8")
-
     def __repr__(self):
         return str(self)
-
 
     def plot(self):
         from matplotlib import pyplot as plt
 
         trajectory_descriptions = [x.description for x in self.results[0].starting_trajectories]
-
 
         # Plot in reverse order so the best one is always on top
         reversed_results = list(reversed(self.results))
@@ -249,6 +247,7 @@ class InferenceResultsCollection(SerialisableObject):
                                               *args, **kwargs)
 
 
+@unicode_compatible
 class InferenceResult(SerialisableObject, MemoisableObject):
 
     __inference = None
@@ -544,7 +543,7 @@ class InferenceResult(SerialisableObject, MemoisableObject):
             if kwargs is None:
                 kwargs = {}
 
-            for key, value in default_data.iteritems():
+            for key, value in iteritems(default_data):
                 if key not in kwargs:
                     kwargs[key] = value
 
@@ -626,7 +625,7 @@ class InferenceResult(SerialisableObject, MemoisableObject):
 
                 list_.append((trajectory, kwargs_optimal_trajectories))
 
-        for description, trajectories_list in trajectories_by_description.iteritems():
+        for description, trajectories_list in iteritems(trajectories_by_description):
             if len(trajectories_by_description) > 1:
                 plt.figure()
             plt.title(description)
@@ -638,7 +637,7 @@ class InferenceResult(SerialisableObject, MemoisableObject):
                 plt.legend(bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.0)
 
 
-    def __unicode__(self):
+    def __str__(self):
         return u"""
         {self.__class__!r}
         Starting Parameters: {self.starting_parameters!r}
@@ -653,9 +652,6 @@ class InferenceResult(SerialisableObject, MemoisableObject):
 
     def __repr__(self):
         return str(self)
-
-    def __str__(self):
-        return unicode(self).encode('utf8')
 
     @classmethod
     def to_yaml(cls, dumper, data):

--- a/src/means/io/__init__.py
+++ b/src/means/io/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Module for Input/Output operations.
 -----------------------------------
@@ -30,5 +31,5 @@ If the :mod:`libsbml` is installed in the user's system and has the appropriate 
 the function :func:`means.io.read_sbml` can be used to parse the files in SBML format
 to :class:`means.core.Model` objects.
 """
-from serialise import dump, load, to_file, from_file
-from sbml import read_sbml
+from .serialise import dump, load, to_file, from_file
+from .sbml import read_sbml

--- a/src/means/io/latex.py
+++ b/src/means/io/latex.py
@@ -22,16 +22,8 @@ class LatexPrintableObject(object):
         :param filename_or_file_handle: filename or already opened file handle to output to
         :return:
         """
-
-        if isinstance(filename_or_file_handle, basestring):
-            file_handle = file(filename_or_file_handle, 'w')
-            we_opened = True
-        else:
-            file_handle = filename_or_file_handle
-            we_opened = False
-
         try:
-            file_handle.write(self.latex)
-        finally:
-            if we_opened:
-                file_handle.close()
+            with open(filename_or_file_handle, 'w') as f:
+                f.write(self.latex)
+        except TypeError:
+            filename_or_file_handle.write(self.latex)

--- a/src/means/io/latex.py
+++ b/src/means/io/latex.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 
 

--- a/src/means/io/sbml.py
+++ b/src/means/io/sbml.py
@@ -1,5 +1,8 @@
+from __future__ import absolute_import, print_function
+
 from collections import namedtuple
 import os
+
 import sympy
 import numpy as np
 from means.core.model import Model

--- a/src/means/io/serialise.py
+++ b/src/means/io/serialise.py
@@ -69,33 +69,34 @@ def to_file(data, filename_or_file_object):
 
     :param data: Object to write to file
     :param filename_or_file_object: filename/or opened file buffer to write to
-    :type filename_or_file_object: basestring|file
+    :type filename_or_file_object: string|file
     """
-    if isinstance(filename_or_file_object, basestring):
-        file_ = open(filename_or_file_object, 'w')
-        we_opened = True
-    else:
-        file_ = filename_or_file_object
-        we_opened = False
-
     try:
-        file_.write(dump(data))
-    finally:
-        if we_opened:
-            file_.close()
+        file = open(filename_or_file_object, 'w')
+    except TypeError:
+        filename_or_file_object.write(dump(data))
+    else:
+        try:
+            file.write(dump(data))
+        finally:
+            file.close()
 
 def from_file(filename_or_file_object):
     """
     Read data from the specified file.
     :param filename_or_file_object: filename of the file or an opened :class:`file` buffer to that file
-    :type filename_or_file_object: basestring|file
+    :type filename_or_file_object: string|file
     :return:
     """
     try:
-        with open(filename_or_file_object, 'r') as f:
-            data = load(f.read())
+        file = open(filename_or_file_object, 'r')
     except TypeError:
         data = load(filename_or_file_object.read())
+    else:
+        try:
+            data = load(file.read())
+        finally:
+            file.close()
 
     return data
 

--- a/src/means/io/serialise.py
+++ b/src/means/io/serialise.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import yaml
 import numpy as np
 

--- a/src/means/io/serialise.py
+++ b/src/means/io/serialise.py
@@ -91,18 +91,11 @@ def from_file(filename_or_file_object):
     :type filename_or_file_object: basestring|file
     :return:
     """
-    if isinstance(filename_or_file_object, basestring):
-        file_ = open(filename_or_file_object, 'r')
-        we_opened = True
-    else:
-        we_opened = False
-        file_ = filename_or_file_object
-
     try:
-        data = load(file_.read())
-    finally:
-        if we_opened:
-            file_.close()
+        with open(filename_or_file_object, 'r') as f:
+            data = load(f.read())
+    except TypeError:
+        data = load(filename_or_file_object.read())
 
     return data
 

--- a/src/means/simulation/__init__.py
+++ b/src/means/simulation/__init__.py
@@ -1,10 +1,12 @@
+from __future__ import absolute_import, print_function
 """
 Routines for stochastic and deterministic simulation.
 """
 from means.simulation.descriptors import SensitivityTerm, PerturbedTerm
-from simulate import Simulation, SimulationWithSensitivities
-from trajectory import Trajectory, TrajectoryWithSensitivityData, TrajectoryCollection
-from solvers import SolverException
-from ssa import SSASimulation
 
-import solvers
+from .simulate import Simulation, SimulationWithSensitivities
+from .trajectory import Trajectory, TrajectoryWithSensitivityData, TrajectoryCollection
+from .solvers import SolverException
+from .ssa import SSASimulation
+
+from . import solvers

--- a/src/means/simulation/descriptors.py
+++ b/src/means/simulation/descriptors.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Simulation Descriptors
 ----

--- a/src/means/simulation/simulate.py
+++ b/src/means/simulation/simulate.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Simulate
 --------
@@ -8,7 +9,7 @@ dynamic of an :class:`~means.core.problems.ODEProblem`.
 A wide range of numerical solver are available:
 
 >>> from means import Simulation
->>> print Simulation.supported_solvers()
+>>> print(Simulation.supported_solvers())
 
 In order to simulate a system, it is necessary to provide values for
 the initial conditions and parameters (constants):
@@ -35,6 +36,7 @@ See the documentation of :class:`Simulation` for additional information.
 """
 
 import numpy as np
+
 from means.io.serialise import SerialisableObject
 from means.simulation.solvers import available_solvers
 from means.simulation.trajectory import Trajectory, TrajectoryWithSensitivityData, TrajectoryCollection

--- a/src/means/simulation/simulate.py
+++ b/src/means/simulation/simulate.py
@@ -47,11 +47,11 @@ def _validate_problem(problem):
     problem.validate()
 
     if problem.method == "MEA":
-        moments = filter(lambda x: isinstance(x, Moment), problem.left_hand_side_descriptors)
-        if problem.left_hand_side.rows != len(moments):
+        moments = [x for x in problem.left_hand_side_descriptors if isinstance(x, Moment)]
+        if problem.left_hand_side.rows != moments:
             raise ValueError("There are {0} equations and {1} moments. "
                              "For MEA problems, the same number is expected.".format(problem.left_hand_side.rows,
-                                                                                     len(moments)))
+                                                                                     moments))
     elif problem.method == 'LNA':
         # FIXME: do some validation for LNA here
         pass

--- a/src/means/simulation/simulate.py
+++ b/src/means/simulation/simulate.py
@@ -48,10 +48,10 @@ def _validate_problem(problem):
 
     if problem.method == "MEA":
         moments = [x for x in problem.left_hand_side_descriptors if isinstance(x, Moment)]
-        if problem.left_hand_side.rows != moments:
+        if problem.left_hand_side.rows != len(moments):
             raise ValueError("There are {0} equations and {1} moments. "
                              "For MEA problems, the same number is expected.".format(problem.left_hand_side.rows,
-                                                                                     moments))
+                                                                                     len(moments)))
     elif problem.method == 'LNA':
         # FIXME: do some validation for LNA here
         pass

--- a/src/means/simulation/solvers.py
+++ b/src/means/simulation/solvers.py
@@ -11,6 +11,7 @@ import inspect
 from assimulo.problem import Explicit_Problem
 import numpy as np
 
+from means.compat import iteritems
 from means.simulation import SensitivityTerm
 from means.simulation.trajectory import Trajectory, TrajectoryWithSensitivityData
 from means.util.memoisation import memoised_property, MemoisableObject
@@ -107,7 +108,7 @@ def parse_flag(exception_message):
 #-- Base solver functionality ---------------------------------------------------------------
 
 def _set_kwargs_as_attributes(instance, **kwargs):
-    for attribute, value in kwargs.iteritems():
+    for attribute, value in iteritems(kwargs):
         setattr(instance, attribute, value)
     return instance
 

--- a/src/means/simulation/solvers.py
+++ b/src/means/simulation/solvers.py
@@ -1,15 +1,18 @@
+from __future__ import absolute_import, print_function
 """
 Solvers
 -------
 
 This part of the package provides wrappers around Assimulo solvers.
 """
+import sys
+import inspect
+
 from assimulo.problem import Explicit_Problem
 import numpy as np
-import sys
+
 from means.simulation import SensitivityTerm
 from means.simulation.trajectory import Trajectory, TrajectoryWithSensitivityData
-import inspect
 from means.util.memoisation import memoised_property, MemoisableObject
 from means.util.sympyhelpers import to_one_dim_array
 
@@ -575,8 +578,3 @@ class ODE15sSolverWithSensitivities(SensitivitySolverBase, ODE15sMixin):
         solver.usesens = True
         solver.report_continuously = True
         return solver
-
-
-
-
-

--- a/src/means/simulation/solvers.py
+++ b/src/means/simulation/solvers.py
@@ -213,7 +213,7 @@ class SolverBase(MemoisableObject):
         """
         Property That would return the exception class thrown by a specific solver the subclases can override.
         """
-        return None
+        return Exception
 
     @memoised_property
     def _solver(self):

--- a/src/means/simulation/ssa.py
+++ b/src/means/simulation/ssa.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Gillespie Stochastic Simulation Algorithm
 ----
@@ -9,7 +10,9 @@ number of species, there are many superior implementations available.
 """
 
 import multiprocessing
+
 import numpy as np
+
 from means.simulation.trajectory import Trajectory, TrajectoryCollection
 from means.io.serialise import SerialisableObject
 from means.util.moment_counters import generate_n_and_k_counters
@@ -268,6 +271,3 @@ class _SSAGenerator(object):
                         spot, desc in zip(species_over_time, descriptors)]
 
         return trajectories
-
-
-

--- a/src/means/simulation/trajectory.py
+++ b/src/means/simulation/trajectory.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Trajectories
 --------
@@ -18,7 +19,9 @@ method to help representation.
 
 import operator
 import numbers
+
 import numpy as np
+
 from means.core.descriptors import Descriptor, Moment
 from means.io.serialise import SerialisableObject
 from means.simulation import SensitivityTerm
@@ -531,4 +534,3 @@ class TrajectoryCollection(SerialisableObject):
 
     def __ne__(self, other):
         return not self == other
-

--- a/src/means/simulation/trajectory.py
+++ b/src/means/simulation/trajectory.py
@@ -22,6 +22,7 @@ import numbers
 
 import numpy as np
 
+from means.compat import unicode_compatible
 from means.core.descriptors import Descriptor, Moment
 from means.io.serialise import SerialisableObject
 from means.simulation import SensitivityTerm
@@ -380,6 +381,7 @@ def perturbed_trajectory(trajectory, sensitivity_trajectory, delta=1e-4):
                                     delta))
 
 
+@unicode_compatible
 class TrajectoryCollection(SerialisableObject):
     """
     A container of trajectories with representation functions for matplotlib and IPythonNoteBook.
@@ -514,11 +516,8 @@ class TrajectoryCollection(SerialisableObject):
         from IPython.display import SVG
         return SVG(self._repr_svg_())
 
-    def __unicode__(self):
-        return u"<{self.__class__.__name__}>\n{self.trajectories!r}".format(self=self)
-
     def __str__(self):
-        return unicode(self).encode('utf-8')
+        return u"<{self.__class__.__name__}>\n{self.trajectories!r}".format(self=self)
 
     def __repr__(self):
         return str(self)

--- a/src/means/simulation/trajectory.py
+++ b/src/means/simulation/trajectory.py
@@ -209,7 +209,14 @@ class Trajectory(SerialisableObject):
     def __add__(self, other):
         return self._arithmetic_operation(other, operator.add)
     def __div__(self, other):
+        # / in python 2
         return self._arithmetic_operation(other, operator.div)
+    def __truediv__(self, other):
+        # / in python 3 (or 2 with future import)
+        return self._arithmetic_operation(other, operator.truediv)
+    def __floordiv__(self, other):
+        # // in python 2 and 3
+        return self._arithmetic_operation(other, operator.floordiv)
     def __mul__(self, other):
         return self._arithmetic_operation(other, operator.mul)
     def __sub__(self, other):

--- a/src/means/tests/matlab_trajectory_regressions/test_trajectories.py
+++ b/src/means/tests/matlab_trajectory_regressions/test_trajectories.py
@@ -1,10 +1,14 @@
+from __future__ import absolute_import, print_function
+
 import os
 import unittest
+
+import numpy as np
 from numpy.testing import assert_array_almost_equal
 import scipy.io.matlab
+
 import means
 import means.examples
-import numpy as np
 from means.simulation import SolverException
 
 MODELS = {'p53': means.examples.MODEL_P53}
@@ -101,5 +105,3 @@ class TestODE15SFailsWhereMatlabDoes(unittest.TestCase):
             self.assertAlmostEqual(base_exception.t, 17.35795, places=1)
         else:
             self.fail('ode15s was able to reach output without throwing and exception')
-
-

--- a/src/means/tests/test_LNA.py
+++ b/src/means/tests/test_LNA.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import unittest
 
 import sympy
@@ -43,4 +45,3 @@ class TestLNA(unittest.TestCase):
 
         assert_sympy_expressions_equal(correct_rhs, answer_rhs)
         self.assertEqual(correct_lhs, answer_lhs)
-

--- a/src/means/tests/test_closure_gamma.py
+++ b/src/means/tests/test_closure_gamma.py
@@ -1,5 +1,9 @@
+from __future__ import absolute_import, print_function
+
 import unittest
+
 import sympy
+
 from means.util.sympyhelpers import sympy_expressions_equal
 from means.util.sympyhelpers import to_sympy_matrix
 from means.approximation.mea.closure_gamma import GammaClosure

--- a/src/means/tests/test_closure_log_normal.py
+++ b/src/means/tests/test_closure_log_normal.py
@@ -1,6 +1,10 @@
+from __future__ import absolute_import, print_function
+
 import unittest
-from means.core import Moment
+
 import sympy
+
+from means.core import Moment
 from means.approximation.mea.closure_log_normal import LogNormalClosure
 from means.util.sympyhelpers import sympy_expressions_equal
 from means.util.sympyhelpers import to_sympy_matrix
@@ -185,7 +189,7 @@ class TestLogNormalCloser(unittest.TestCase):
         answer = closer.close(self.__mfk, central_from_raw_exprs, self.__n_counter, self.__k_counter)
 
 
-        #print (answer -expected).applyfunc(sympy.simplify)
+        #print((answer - expected).applyfunc(sympy.simplify))
         self.assertTrue(sympy_expressions_equal(answer, expected))
 
 

--- a/src/means/tests/test_closure_normal.py
+++ b/src/means/tests/test_closure_normal.py
@@ -1,5 +1,9 @@
+from __future__ import absolute_import, print_function
+
 import unittest
+
 import sympy
+
 from means.approximation.mea.closure_normal import NormalClosure
 from means.core import Moment
 from means.util.sympyhelpers import sympy_expressions_equal
@@ -295,4 +299,3 @@ class TestNormalCloser(unittest.TestCase):
         closer = NormalClosure(3, multivariate=True)
         answer = [p for p in closer._generate_partitions(test_list_for_partition)]
         self.assertEqual(answer, expected)
-

--- a/src/means/tests/test_dmu_over_dt.py
+++ b/src/means/tests/test_dmu_over_dt.py
@@ -1,5 +1,9 @@
+from __future__ import absolute_import, print_function
+
 import unittest
+
 import sympy as sp
+
 from means.approximation.mea.dmu_over_dt import generate_dmu_over_dt
 from means.core import Moment
 from means.approximation.mea.moment_expansion_approximation import MomentExpansionApproximation

--- a/src/means/tests/test_eq_central_moments.py
+++ b/src/means/tests/test_eq_central_moments.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import unittest
 
 import sympy

--- a/src/means/tests/test_eq_central_moments.py
+++ b/src/means/tests/test_eq_central_moments.py
@@ -98,7 +98,7 @@ class CentralMomentsTestCase(unittest.TestCase):
         ])
 
 
-        species = sympy.Matrix(map(sympy.var, ['y_0', 'y_1']))
+        species = sympy.Matrix([sympy.var(v) for v in ['y_0', 'y_1']])
 
         propensities = to_sympy_matrix(['c_0*y_0*(y_0 + y_1 - 181)',
                                                         'c_1*(-y_0 - y_1 + 301)',

--- a/src/means/tests/test_eq_mixed_moments.py
+++ b/src/means/tests/test_eq_mixed_moments.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import unittest
 
 import sympy
@@ -54,4 +56,3 @@ class TestEqMixedMoments(unittest.TestCase):
         answer = dbdt_calc.get(k_vec,ek_counter).T
         result = to_sympy_matrix(["c_0 - c_1*y_0 - c_2*y_0*y_2/(c_6 + y_0)"," 0"," 0"," 0"," c_2*y_0/(c_6 + y_0)**2 - c_2/(c_6 + y_0)"," 0"," -c_2*y_0*y_2/(c_6 + y_0)**3 + c_2*y_2/(c_6 + y_0)**2"])
         assert_sympy_expressions_equal(answer, result)
-

--- a/src/means/tests/test_hypercube.py
+++ b/src/means/tests/test_hypercube.py
@@ -1,7 +1,11 @@
+from __future__ import absolute_import, print_function
+
 import unittest
 import random
+
 import numpy as np
 from numpy.testing import assert_array_almost_equal
+
 from means.inference.hypercube import hypercube
 
 

--- a/src/means/tests/test_inference.py
+++ b/src/means/tests/test_inference.py
@@ -1,9 +1,13 @@
+from __future__ import absolute_import, print_function
+
 import random
 import unittest
+
+import numpy as np
 from numpy.testing import assert_array_almost_equal
 from sympy import Symbol, Float, MutableDenseMatrix
+
 from means.core import Moment, ODEProblem
-import numpy as np
 from means.inference import Inference, InferenceWithRestarts
 # We need renaming as otherwise nose picks it up as a test
 from means.simulation import Trajectory
@@ -449,7 +453,3 @@ class TestInferenceWithRestarts(unittest.TestCase):
 
 class TestInferenceWithRestartsMultiProcessing(TestInferenceWithRestarts):
     number_of_processes = 2
-
-
-
-

--- a/src/means/tests/test_inference.py
+++ b/src/means/tests/test_inference.py
@@ -95,7 +95,7 @@ class TestInference(unittest.TestCase):
                 parameters,
                 variables)
 
-            self.assertEqual(values_with_variability, correct_values_with_variability)
+            self.assertEqual(values_with_variability, list(correct_values_with_variability))
             self.assertEqual(constraints, correct_constraints)
 
         parameters = [0.001, 0.5, 330.0]
@@ -115,8 +115,8 @@ class TestInference(unittest.TestCase):
             p = Inference(self.dimer_problem, parameters, initial_conditions,
                           variable_parameters, [Trajectory([1, 2, 3], [1, 2, 3], Moment([1], symbol='x'))])
 
-            self.assertEquals(p.starting_parameters_with_variability, expected_parameters_with_variability)
-            self.assertEqual(p.starting_conditions_with_variability, expected_initial_conditions_with_variability)
+            self.assertEquals(p.starting_parameters_with_variability, list(expected_parameters_with_variability))
+            self.assertEqual(p.starting_conditions_with_variability, list(expected_initial_conditions_with_variability))
             self.assertEqual(p.constraints, expected_constraints)
 
         symbol_keys = {Symbol('c_1'): None, Symbol('c_2'): (329, 330), Symbol('y_0'): [319, 321]}

--- a/src/means/tests/test_io.py
+++ b/src/means/tests/test_io.py
@@ -1,7 +1,15 @@
+from __future__ import absolute_import, print_function
+
 import os
 import unittest
+from StringIO import StringIO
+from tempfile import mkstemp
+import cPickle as pickle
+
+import numpy as np
 from assimulo.solvers.sundials import CVodeError
 from sympy import Symbol, MutableDenseMatrix, Float
+
 from means import TrajectoryCollection, SolverException
 from means.core import ODEProblem, Moment, VarianceTerm
 from means.inference import Inference
@@ -10,10 +18,6 @@ from means.io.serialise import dump, load
 from means.examples.sample_models import MODEL_P53, MODEL_MICHAELIS_MENTEN, MODEL_LOTKA_VOLTERRA, \
                                          MODEL_HES1, MODEL_DIMERISATION
 from means.simulation import Trajectory, TrajectoryWithSensitivityData, SensitivityTerm, Simulation
-import numpy as np
-from StringIO import StringIO
-from tempfile import mkstemp
-import cPickle as pickle
 
 def _sample_problem():
     lhs_terms = [Moment(np.array([1, 0, 0]), symbol='y_0'),
@@ -242,5 +246,3 @@ class TestPickleSerialisation(TestSerialisation):
 
         e = SolverException(None, CVodeError('Test', 14.9))
         self._roundtrip(e)
-
-

--- a/src/means/tests/test_io.py
+++ b/src/means/tests/test_io.py
@@ -2,15 +2,18 @@ from __future__ import absolute_import, print_function
 
 import os
 import unittest
-from StringIO import StringIO
 from tempfile import mkstemp
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 
 import numpy as np
 from assimulo.solvers.sundials import CVodeError
 from sympy import Symbol, MutableDenseMatrix, Float
 
 from means import TrajectoryCollection, SolverException
+from means.compat import StringIO
 from means.core import ODEProblem, Moment, VarianceTerm
 from means.inference import Inference
 from means.inference.results import InferenceResult, NormalConvergenceStatus

--- a/src/means/tests/test_mea_helpers.py
+++ b/src/means/tests/test_mea_helpers.py
@@ -1,5 +1,9 @@
+from __future__ import absolute_import, print_function
+
 import unittest
+
 import sympy as sp
+
 from means.approximation.mea.mea_helpers import get_one_over_n_factorial, derive_expr_from_counter_entry
 from means.util.sympyhelpers import assert_sympy_expressions_equal
 

--- a/src/means/tests/test_memoised_property.py
+++ b/src/means/tests/test_memoised_property.py
@@ -1,4 +1,7 @@
+from __future__ import absolute_import, print_function
+
 import unittest
+
 from means.util.memoisation import memoised_property, MemoisableObject
 
 

--- a/src/means/tests/test_model.py
+++ b/src/means/tests/test_model.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import unittest
 
 import sympy

--- a/src/means/tests/test_model.py
+++ b/src/means/tests/test_model.py
@@ -202,18 +202,22 @@ class TestModelInitialisation(unittest.TestCase):
         # List
         m = Model(self.SAMPLE_VARIABLES,
                   self.SAMPLE_CONSTANTS,
-                  map(sympy.sympify, ['c_0*y_0*(y_0 + y_1 - 181)',
-                                      'c_1*(-y_0 - y_1 + 301)',
-                                      'c_2*(-y_0 - y_1 + 301)']),
+                  [sympy.sympify(v) for v in [
+                        'c_0*y_0*(y_0 + y_1 - 181)',
+                        'c_1*(-y_0 - y_1 + 301)',
+                        'c_2*(-y_0 - y_1 + 301)',
+                  ]],
                   self.SAMPLE_STOICHIOMETRY_MATRIX)
         self.assertEqual(m.propensities, answer)
 
         # Double list
         m = Model(self.SAMPLE_VARIABLES,
                   self.SAMPLE_CONSTANTS,
-                  [map(sympy.sympify, ['c_0*y_0*(y_0 + y_1 - 181)',
-                                       'c_1*(-y_0 - y_1 + 301)',
-                                       'c_2*(-y_0 - y_1 + 301)'])],
+                  [[sympy.sympify(v) for v in [
+                        'c_0*y_0*(y_0 + y_1 - 181)',
+                        'c_1*(-y_0 - y_1 + 301)',
+                        'c_2*(-y_0 - y_1 + 301)',
+                  ]]],
                   self.SAMPLE_STOICHIOMETRY_MATRIX)
         self.assertEqual(m.propensities, answer)
 

--- a/src/means/tests/test_moment_expansion_approximation.py
+++ b/src/means/tests/test_moment_expansion_approximation.py
@@ -1,6 +1,10 @@
+from __future__ import absolute_import, print_function
+
 import unittest
+
 import sympy
 from numpy import array
+
 from means.approximation.mea.moment_expansion_approximation import MomentExpansionApproximation
 from means.core import Moment, ODEProblem, Model
 from means.util.sympyhelpers import sympy_expressions_equal

--- a/src/means/tests/test_ode_problem.py
+++ b/src/means/tests/test_ode_problem.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import unittest
 
 import numpy as np

--- a/src/means/tests/test_raw_to_central.py
+++ b/src/means/tests/test_raw_to_central.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import unittest
 
 import sympy

--- a/src/means/tests/test_simulate.py
+++ b/src/means/tests/test_simulate.py
@@ -1,12 +1,16 @@
+from __future__ import absolute_import, print_function
+
+import random
 import unittest
+
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+from sympy import Symbol, MutableDenseMatrix, symbols, Float
+
 import means
 from means.util.sympyhelpers import to_sympy_matrix
 from means.core import ODEProblem, ODETermBase, Moment, VarianceTerm
 from means.simulation import Simulation
-from numpy.testing import assert_array_almost_equal
-import numpy as np
-import random
-from sympy import Symbol, MutableDenseMatrix, symbols, Float
 
 
 class ConstantDerivativesProblem(ODEProblem):
@@ -27,16 +31,16 @@ class TestSimulate(unittest.TestCase):
         y_1_trajectory = trajectories_dict[Symbol('y_1')]
         y_2_trajectory = trajectories_dict[Symbol('y_2')]
 
-        print 'Kwargs: {0!r} ... '.format(solver_kwargs),
+        print('Kwargs: {0!r} ... '.format(solver_kwargs), end=' ')
         try:
             assert_array_almost_equal(y_1_trajectory.values, [3, 3, 3, 3])
             assert_array_almost_equal(y_2_trajectory.values, [2, 3, 4, 5])
             assert_array_almost_equal(y_1_trajectory.timepoints, [0, 1, 2, 3])
             assert_array_almost_equal(y_2_trajectory.timepoints, [0, 1, 2, 3])
         except AssertionError:
-            print 'FAILED'
+            print('FAILED')
             raise
-        print 'OK'
+        print('OK')
 
     def test_simple_problem_for_all_solvers(self):
         for solver in Simulation.supported_solvers():
@@ -337,7 +341,7 @@ class TestSimulateRegressionForPopularModels(unittest.TestCase):
 
         results = simulation.simulate_system(parameters, initial_conditions, timepoints)
         results_dict = {t.description: t.values for t in results}
-        
+
         answers = np.array([
             [301. ,  256.51498358,  229.8950497 ,  211.52095108, 197.42292629,  185.71844205,  175.44199006,  166.06812179, 157.29396586,  148.94973631,  140.94453324,  133.21443813, 125.71851091,  118.44071938,  111.37876063,  104.52885369, 97.88778992,   91.45881189,   85.24893775,   79.26303981, 73.50431791,   67.97791546,   62.69000734,   57.64518316, 52.84648676,   48.29649121,   43.99713149,   39.9492471 , 36.15253692,   32.60546311,   29.30505184,   26.24697504, 23.42559667,   20.83400181,   18.46410003,   16.30672602,14.35177251,   12.58834607,   11.00490033,    9.58948675,8.32991558,    7.21394911,    6.22942185,    5.36444895,4.60756355,    3.94781273,    3.3748562 ,    2.8789987 ,2.45128862,    2.08350738,    1.76816461],
             [0. ,    2.36069281,    7.74736822,   14.71042241, 22.53210817,   30.82468744,   39.36702926,   48.02796564, 56.72586425,   65.40844338,   74.04167272,   82.60194102, 91.07219255,   99.43927128,  107.69231586,  115.82183747,123.81951774,  131.67785512,  139.3896348 ,  146.94773612,154.34527892,  161.5756526 ,  168.63237519,  175.50906398,182.19957199,  188.69804269,  194.99897458,  201.09726961,206.98828324,  212.6679015 ,  218.132621  ,  223.37961716,228.40681457,  233.21291588,  237.79747755,  242.16092232,246.3045504 ,  250.23053657,  253.94192056,  257.44257357,260.73714751,  263.83100992,  266.73019086,  269.44129181,271.97139158,  274.32796251,  276.51876968,  278.5518216 ,280.43523052,  282.17715464,  283.78572641]
@@ -346,4 +350,3 @@ class TestSimulateRegressionForPopularModels(unittest.TestCase):
 
         assert_array_almost_equal(results_dict[Moment(np.array([1, 0]), symbol=y_0)], answers[0])
         assert_array_almost_equal(results_dict[Moment(np.array([0, 1]), symbol=y_1)], answers[1])
-

--- a/src/means/tests/test_simulate_solvers.py
+++ b/src/means/tests/test_simulate_solvers.py
@@ -1,6 +1,10 @@
+from __future__ import absolute_import, print_function
+
 import unittest
+
 import numpy as np
 import sympy
+
 from means.core import ODETermBase
 from means.simulation import Trajectory, TrajectoryWithSensitivityData, SensitivityTerm
 from means.simulation.solvers import _wrap_results_to_trajectories, _add_sensitivity_data_to_trajectories
@@ -56,4 +60,3 @@ class TestSensitivitySolverBase(unittest.TestCase):
 
         self.assertEqual(actual_t1, expected_t1)
         self.assertEqual(actual_t2, expected_t2)
-

--- a/src/means/tests/test_ssa.py
+++ b/src/means/tests/test_ssa.py
@@ -1,5 +1,9 @@
+from __future__ import absolute_import, print_function
+
 import unittest
+
 import sympy
+
 from means.simulation import Trajectory
 from means import  Moment
 from means import SSASimulation

--- a/src/means/tests/test_sympyhelpers.py
+++ b/src/means/tests/test_sympyhelpers.py
@@ -1,5 +1,9 @@
+from __future__ import absolute_import, print_function
+
 import unittest
+
 import sympy
+
 from means.util.sympyhelpers import to_sympy_matrix, assert_sympy_expressions_equal, sympy_expressions_equal
 from means.util.sympyhelpers import substitute_all
 

--- a/src/means/tests/test_trajectory.py
+++ b/src/means/tests/test_trajectory.py
@@ -1,9 +1,13 @@
-import unittest
-import numpy as np
-from means.simulation import Trajectory, TrajectoryWithSensitivityData, TrajectoryCollection
-from means.core import Moment
+from __future__ import absolute_import, print_function
+
 import os
 import tempfile
+import unittest
+
+import numpy as np
+
+from means.simulation import Trajectory, TrajectoryWithSensitivityData, TrajectoryCollection
+from means.core import Moment
 
 class TestTrajectory(unittest.TestCase):
 
@@ -102,6 +106,3 @@ class TestTrajectoriesToCSV(unittest.TestCase):
                 tc.to_csv(out)
         finally:
             os.unlink(file)
-
-
-

--- a/src/means/util/__init__.py
+++ b/src/means/util/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Utilities
 ---------
@@ -10,8 +11,8 @@ These functions are designed to be package-specific.
 The users of the software are generally discouraged to use any of these functions.
 """
 
-import sympyhelpers
-from memoisation import MemoisableObject, memoised_property
-import memoisation
-import decorators
-from decorators import cache
+from . import sympyhelpers
+from .memoisation import MemoisableObject, memoised_property
+from . import memoisation
+from . import decorators
+from .decorators import cache

--- a/src/means/util/decorators.py
+++ b/src/means/util/decorators.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 from functools import wraps
 
 def cache(func):

--- a/src/means/util/logs.py
+++ b/src/means/util/logs.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import logging
 
 def get_logger(name):

--- a/src/means/util/memoisation.py
+++ b/src/means/util/memoisation.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 from functools import wraps
 
 def memoised_property(function):

--- a/src/means/util/moment_counters.py
+++ b/src/means/util/moment_counters.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 MEANS Helpers
 -----
@@ -59,4 +60,3 @@ def generate_n_and_k_counters(max_order, species, central_symbols_prefix="M_", r
         n_counter += [Moment(c, s) for c,s in zip(n_counter_descriptors, n_counter_symbols)]
 
         return n_counter, k_counter
-

--- a/src/means/util/moment_counters.py
+++ b/src/means/util/moment_counters.py
@@ -45,7 +45,7 @@ def generate_n_and_k_counters(max_order, species, central_symbols_prefix="M_", r
 
         #this mimics the order in the original code
         print(k_counter_descriptors)
-        k_counter_descriptors = sorted(k_counter_descriptors, key=lambda x, y: sum(x) - sum(y))
+        k_counter_descriptors = sorted(k_counter_descriptors, key=sum)
         #k_counter_descriptors = [[r for r in reversed(k)] for k in k_counter_descriptors]
 
         k_counter_symbols = [sp.Symbol(raw_symbols_prefix + "_".join([str(s) for s in count]))

--- a/src/means/util/moment_counters.py
+++ b/src/means/util/moment_counters.py
@@ -44,7 +44,8 @@ def generate_n_and_k_counters(max_order, species, central_symbols_prefix="M_", r
                                  if 1 < sum(i) <= n_moments]
 
         #this mimics the order in the original code
-        k_counter_descriptors = sorted(k_counter_descriptors,lambda x,y: sum(x) - sum(y))
+        print(k_counter_descriptors)
+        k_counter_descriptors = sorted(k_counter_descriptors, key=lambda x, y: sum(x) - sum(y))
         #k_counter_descriptors = [[r for r in reversed(k)] for k in k_counter_descriptors]
 
         k_counter_symbols = [sp.Symbol(raw_symbols_prefix + "_".join([str(s) for s in count]))

--- a/src/means/util/moment_counters.py
+++ b/src/means/util/moment_counters.py
@@ -44,7 +44,6 @@ def generate_n_and_k_counters(max_order, species, central_symbols_prefix="M_", r
                                  if 1 < sum(i) <= n_moments]
 
         #this mimics the order in the original code
-        print(k_counter_descriptors)
         k_counter_descriptors = sorted(k_counter_descriptors, key=sum)
         #k_counter_descriptors = [[r for r in reversed(k)] for k in k_counter_descriptors]
 

--- a/src/means/util/sympyhelpers.py
+++ b/src/means/util/sympyhelpers.py
@@ -12,6 +12,7 @@ import sympy
 from sympy.core.sympify import SympifyError
 import numpy as np
 
+from means.compat import reduce
 
 def substitute_all(sp_object, pairs):
     """

--- a/src/means/util/sympyhelpers.py
+++ b/src/means/util/sympyhelpers.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 """
 Sympy Helpers
 ----
@@ -5,6 +6,7 @@ Sympy Helpers
 This part of the package provides functions to extend the functionality of sympy,
 or to make MEANS compatible with different versions of sympy.
 """
+import operator
 
 import sympy
 from sympy.core.sympify import SympifyError
@@ -232,8 +234,6 @@ def sum_of_rows(mat):
 def sum_of_cols(mat):
     out = sympy.Matrix([sum(r)for r in (mat.T).tolist()]).T
     return out
-
-import operator
 
 def product(list):
     return reduce(operator.mul, list)

--- a/src/setup.py
+++ b/src/setup.py
@@ -16,19 +16,27 @@ non-expert users in stochastic analysis.
 # numpy and cython are required for assimulo installation, yet their setup.py is badly done
 # so the setup fails. Add these checks so our error message is displayed instead
 # can be removed once assimulo ups their game.
+missing_dependicies = []
+
 try:
     import cython
 except ImportError:
-    raise ImportError('Please install cython first `pip install cython`')
+    missing_dependicies.append('Cython')
 
 try:
     import numpy
 except ImportError:
-    raise ImportError('Please install numpy first `pip install numpy`')
+    missing_dependicies.append('numpy')
+
+if missing_dependicies:
+    raise ImportError('Please install {} first: `pip install {}`'.format(
+        ' and '.join(missing_dependicies),
+        ' '.join(missing_dependicies)
+    ))
 # ---------------------------------------------------------------------------------------------------------
 setup(
     name='means',
-    version='1.0.0',
+    version='1.0.1-dev',
 
     description='Moment Expansion Approximation method implementation with simulation and inference packages',
     long_description=DESCRIPTION,
@@ -58,7 +66,7 @@ setup(
         "matplotlib>=1.1.0",
         "scipy>=0.10.1",
         "PyYAML>=3.10",
-        "Assimulo>=2.5.1",
+        "Assimulo>=2.8",
     ],
     tests_require=['nose'],
     test_suite='nose.collector'


### PR DESCRIPTION
Here's something of a WIP trying to add Python 3 compatibility to MEANS. I'm not familiar with what it precisely does and how, but someone in my lab uses it and you wrote tests (🎉), so it was easy enough to start attacking. Major bits were Implicit relative imports, some builtins are now generators (and moved, e.g. reduce), and some of the string/unicode handling. 

Assimulo is still wonky though, not sure how to do it right 😕 , and I get a ton of "Cannot import name 'ExplicitEuler'" errors (is that a C/Cython thing that the install isn't doing?)

Anyways, Nosetests against the current master (fe16491) with Python 2.7.11 and my not-quite-there environment give me 20 errors (all from the aforementioned) and one other Matplotlib one (didn't install as framework...ignoring that). This branch is currently at 

```
2.7.11 / fe16491: EE..................EE.....E.E.EEEEEEEEE............................................EEEEEE.................
3.5.1  / b5f4bec: EE.FFF....FF...FFF.FEE.....E.E.EEEEEEEEE..............................FFFF.FFF...FFFEEEEEEE..........F.....
```

Most of those fails are mismatching `repr` comparisons out from sympy. I haven't used it and have no idea about the math, could it be because some types (sets, dictionaries) are actually random in Py3 now?

Do you think you're able to throw your knowledge and expertise at this to get a Python 3.x version working?
